### PR TITLE
Use fpm 1.12.0 to avoid uninitialized constant FPM::Package::Deb::Zlib (NameError)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # To build this Docker image:
-#   docker build --build-arg=VERSION="1.11.0" -t fpm:1.11.0 .
+#   docker build --build-arg=VERSION="1.12.0" -t fpm:1.12.0 .
 #
 # To run fpm via Docker:
-#   alias fpm='docker run --user=$(id -u) --rm --mount type=bind,source="$(pwd)",target=/app -it fpm:1.11.0'
+#   alias fpm='docker run --user=$(id -u) --rm --mount type=bind,source="$(pwd)",target=/app -it fpm:1.12.0'
 #
 FROM debian:bullseye-slim
 
-ARG VERSION=1.11.0
+ARG VERSION=1.12.0
 
 RUN apt-get update && \
       apt-get install --no-install-recommends -y ruby ruby-dev rubygems build-essential && \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You need `wget` and `docker` (to run [fpm](https://github.com/jordansissel/fpm))
 
 Build the required FPM docker image with:
 
-    docker build -t fpm:1.11.0 .
+    docker build -t fpm:1.12.0 .
 
 ## Usage
 

--- a/opencl-amd-debian
+++ b/opencl-amd-debian
@@ -12,7 +12,7 @@ set -e -u -o pipefail -o noclobber
 maintainer='Frederik Leonhardt <frederik@leonhardt.co.nz>'
 
 builddeps=('wget' 'docker')
-buildimage='fpm:1.11.0'
+buildimage='fpm:1.12.0'
 
 pkgbuild='opencl-amd.pkgbuild'
 pkgbuild_src='https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=opencl-amd'


### PR DESCRIPTION
Fixes #1 

Version 1.12.0 seems to fix `uninitialized constant FPM::Package::Deb::Zlib (NameError)`

Ref: https://github.com/jordansissel/fpm/blob/master/CHANGELOG.rst#1120-january-19-2021