### PR TITLE
Add git to FPM docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM debian:bullseye-slim
 ARG VERSION=1.11.0
 
 RUN apt-get update && \
-      apt-get install --no-install-recommends -y ruby ruby-dev rubygems build-essential && \
+      apt-get install --no-install-recommends -y ruby ruby-dev rubygems build-essential git && \
       rm -rf /var/lib/apt/lists/*
 
 RUN gem install --no-document fpm -v $VERSION


### PR DESCRIPTION
To avoid 'git: not found (Git::GitExecuteError)'

Fixes #3 