### PR TITLE
Support overriding pkgbuild_src via environment variable

### DIFF
--- a/opencl-amd-debian
+++ b/opencl-amd-debian
@@ -15,7 +15,11 @@ builddeps=('wget' 'docker')
 buildimage='fpm:1.11.0'
 
 pkgbuild='opencl-amd.pkgbuild'
-pkgbuild_src='https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=opencl-amd'
+if [ "${PKGBUILD_SRC:-}" ]; then
+    pkgbuild_src="${PKGBUILD_SRC}"
+else
+    pkgbuild_src='https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=opencl-amd'
+fi
 
 buildroot=$(dirname "$(realpath "$0")")/build
 srcdir="$buildroot/src"


### PR DESCRIPTION
The latest version opencl-amd.pkgbuild is not recommended: https://aur.archlinux.org/packages/opencl-amd/#pinned-776514.

It is useful being able to override the version of pkgbuild to be used. E.g. with:  PKGBUILD_SRC="https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=opencl-amd&id=88cc39d2619dddf7c62fc4e4eb3726ab04cb8f92"